### PR TITLE
Using 'es_ES' has a strange/inconsistent behaviour with NODE_ENV

### DIFF
--- a/_includes/docs/gettingstarted.md
+++ b/_includes/docs/gettingstarted.md
@@ -226,7 +226,12 @@ Thanks to [Makara](http://github.com/krakenjs/makara), kraken has the ability to
 
 
 {% highlight javascript %}
-res.locals.context = { locality: 'es_ES' };
+res.locals.context = { 
+  locality: {
+    language: 'es',
+    country: 'ES'
+  } 
+};
 var model = { name: 'Antonio Banderas' };
 res.render('index',model);
 {% endhighlight %}


### PR DESCRIPTION
Using 'es_ES' has a strange/inconsistent behaviour when the user uses NODE_ENV as production or staging