### PR TITLE
Use padding between sections instead of margins

### DIFF
--- a/_site/CNAME_TMP
+++ b/_site/CNAME_TMP
@@ -1,1 +1,0 @@
-krakenjs.com

--- a/_site/css/kraken.css
+++ b/_site/css/kraken.css
@@ -195,7 +195,7 @@ pre code {
 	position: relative;
 }
 
-#documentation h2, #documentation h3, #documentation h4, #documentation h5 {
+#documentation h2, #documentation h4, #documentation h5 {
 	margin: 2.5em 0 1em;
 }
 
@@ -203,6 +203,10 @@ pre code {
 	padding-bottom: 10px;
 	border-bottom: 1px solid #0d79be;
 	font-weight: bold;
+}
+
+#documentation h3 {
+  padding: 2.5em 0 1em;
 }
 
 #documentation a {

--- a/css/kraken.css
+++ b/css/kraken.css
@@ -195,7 +195,7 @@ pre code {
 	position: relative;
 }
 
-#documentation h2, #documentation h3, #documentation h4, #documentation h5 {
+#documentation h2, #documentation h4, #documentation h5 {
 	margin: 2.5em 0 1em;
 }
 
@@ -203,6 +203,10 @@ pre code {
 	padding-bottom: 10px;
 	border-bottom: 1px solid #0d79be;
 	font-weight: bold;
+}
+
+#documentation h3 {
+  padding: 2.5em 0 1em;
 }
 
 #documentation a {


### PR DESCRIPTION
I was just introduced to kraken.js by @billwscott at JSConf today.  Looks really nice, great work!

Throwing up this PR since I noticed the left hand side menu didn't trigger quite where my eyes were reading.  So I just change the title elements' to use padding to increase their height's so they trigger the menu highlights a little earlier when scrolling.  If this somehow causes more problems than it's worth, feel free to reject :)

Before:

![image](https://cloud.githubusercontent.com/assets/49288/3109353/b96998a8-e698-11e3-8f3c-642febacab53.png)

After:

![image](https://cloud.githubusercontent.com/assets/49288/3109355/c35bf680-e698-11e3-8647-c3c1fba1f4c8.png)
