### PR TITLE
Removed the line,'There is a typo on this page' from gettingstarted.md since typo has been fixed

### DIFF
--- a/_includes/docs/gettingstarted.md
+++ b/_includes/docs/gettingstarted.md
@@ -306,10 +306,7 @@ Bugs and new features should be submitted using [Github issues](https://github.c
 - Open a [pull request](https://github.com/krakenjs/kraken-js/pulls).
 
 
-
-#### There is a typo on this page!
-
-Good catch! This page is built from the `krakenjs.github.io` repository. You can [let us know about it](https://github.com/krakenjs/krakenjs.github.io/issues/new), or better yet, send us a [pull request](https://github.com/krakenjs/krakenjs.github.io/pulls).
+This page is built from the `krakenjs.github.io` repository. To refine the document even further, you can [create an issue](https://github.com/krakenjs/krakenjs.github.io/issues/new), or better yet, submit a [pull request](https://github.com/krakenjs/krakenjs.github.io/pulls).
 
 
 


### PR DESCRIPTION
I went through the document over and over again to only realize that the typo has been fixed. Therefore, I deleted the line that talk about the typo in the page so that souls can focus their energy on finding elixir rather than search for typos on the page which has already been fixed.
