### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ This is the source code for krakenjs.com
 ## Setup
 
 1. Clone this repo
-2. Make sure you have Jekyll setup per [Github's instructions](https://help.github.com/articles/using-jekyll-with-pages)
+2. Make sure you have Jekyll setup per [GitHub's instructions](https://help.github.com/articles/using-jekyll-with-pages)
 3. Run `bundle exec jekyll serve  --watch` from within your repo to generate the pages

--- a/_includes/docs/gettingstarted.md
+++ b/_includes/docs/gettingstarted.md
@@ -297,7 +297,7 @@ Hola Antonio Banderas!
 
 #### How can I contribute to this project?
 
-Bugs and new features should be submitted using [Github issues](https://github.com/krakenjs/kraken-js/issues/new). Please include with a detailed description and the expected behavior. If you would like to submit a change yourself do the following steps.
+Bugs and new features should be submitted using [GitHub issues](https://github.com/krakenjs/kraken-js/issues/new). Please include with a detailed description and the expected behavior. If you would like to submit a change yourself do the following steps.
 
 - Fork it.
 - Create a feature branch.

--- a/_site/README.md
+++ b/_site/README.md
@@ -6,5 +6,5 @@ This is the source code for krakenjs.com
 ## Setup
 
 1. Clone this repo
-2. Make sure you have Jekyll setup per [Github's instructions](https://help.github.com/articles/using-jekyll-with-pages)
+2. Make sure you have Jekyll setup per [GitHub's instructions](https://help.github.com/articles/using-jekyll-with-pages)
 3. Run `bundle exec jekyll serve  --watch` from within your repo to generate the pages

--- a/_site/index.html
+++ b/_site/index.html
@@ -299,7 +299,7 @@ Application entry point
 
 <h4 id="how_can_i_contribute_to_this_project">How can I contribute to this project?</h4>
 
-<p>Bugs and new features should be submitted using <a href="https://github.com/krakenjs/kraken-js/issues/new">Github issues</a>. Please include with a detailed description and the expected behavior. If you would like to submit a change yourself do the following steps.</p>
+<p>Bugs and new features should be submitted using <a href="https://github.com/krakenjs/kraken-js/issues/new">GitHub issues</a>. Please include with a detailed description and the expected behavior. If you would like to submit a change yourself do the following steps.</p>
 
 <ul>
 <li>Fork it.</li>


### PR DESCRIPTION
It's GitHub, not Github (just like it's PayPal, not Paypal) :smile:
