### PR TITLE
update yo kraken instruction to include bower installation

### DIFF
--- a/_includes/docs/gettingstarted.md
+++ b/_includes/docs/gettingstarted.md
@@ -4,7 +4,7 @@
 
 #### 1. Install the generator
 
-Start by installing the generator globally using npm: `sudo npm install -g generator-kraken`
+Start by installing the generator globally using npm: `[sudo] npm install -g yo generator-kraken bower`
 
 
 


### PR DESCRIPTION
The npm install command on the getting started page had diverged from what is in the generator-kraken README. This brings it back in sync
