### PR TITLE
add documentation on installing/using grunt-cli

### DIFF
--- a/_includes/docs/gettingstarted.md
+++ b/_includes/docs/gettingstarted.md
@@ -7,7 +7,7 @@
 
 #### 1. Install the generator
 
-Start by installing the generator globally using npm: `[sudo] npm install -g yo generator-kraken bower`
+Start by installing the generator globally using npm: `[sudo] npm install -g yo generator-kraken bower grunt-cli`
 
 
 

--- a/_includes/docs/gettingstarted.md
+++ b/_includes/docs/gettingstarted.md
@@ -285,6 +285,13 @@ So, in the above example, since the language and country are set to `es` and `ES
 Hola Antonio Banderas!
 {% endhighlight %}
 
+### Grunt tasks
+
+Generated projects include the following grunt tasks by default:
+
+* `$ grunt build` will localize and compile your templates to the `.build` directory, and also copy static assets there
+* `$ grunt test` will run jshint as well as any mocha tests
+
 
 ### FAQ
 


### PR DESCRIPTION
This consumes https://github.com/krakenjs/krakenjs.github.io/pull/21 and adds an additional section to explain the two default grunt tasks (test and build) in generated projects.