### PR TITLE
Make lusca and kappa images link to their respective pages

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -20,14 +20,18 @@
 		<div class="container">
             <div id="modules">
 	            <div class="lusca col-sm-3">
-                    <img src="{{site.baseurl}}/img/Lusca.svg" />
-                    <strong>Lusca</strong>
-                    <a href="http://github.com/krakenjs/lusca">Application security</a>
+                    <a href="http://github.com/krakenjs/lusca">
+                        <img src="{{site.baseurl}}/img/Lusca.svg" />
+                        <strong>Lusca</strong>
+                        Application security
+                    </a>
 	            </div>
 				<div class="kappa col-sm-3">
-                    <img src="{{site.baseurl}}img/Kappa.png" />
-	                <strong>Kappa</strong>
-	                <a href="http://github.com/krakenjs/kappa">NPM Proxy</a>
+                    <a href="http://github.com/krakenjs/kappa">
+                       <img src="{{site.baseurl}}img/Kappa.png" />
+	                   <strong>Kappa</strong>
+	                   NPM Proxy
+                    </a>
 	            </div>
 	            <div class="makara col-sm-3">
                     <a href="makara.html"><img src="{{site.baseurl}}/img/Makara.svg"><strong>Makara</strong>Dust I18N</a>


### PR DESCRIPTION
Hi,

I tried to check out the independent modules at http://krakenjs.com/index.html and i realized that only the last two images are linking to the docs. So i fixed it.

I hope it was a bug and not an intended behavior.
