### PR TITLE
Use kramdown instead of redcarpet

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,4 @@ name: krakenjs
 description: Give your node.js express apps some extra arms
 extendedDescription: Built at PayPal, Kraken builds upon express and enables environment-aware, dynamic configuration, advanced middleware capabilities, security, and app lifecycle events.
 url: http://krakenjs.com
-markdown: redcarpet
-redcarpet:
-  extensions: [with_toc_data]
+markdown: kramdown


### PR DESCRIPTION
In response to https://github.com/krakenjs/krakenjs.github.io/issues/59 i checked if this is going to be a hassle - it turns out (after clicking through all/most of the pages) it is fairly painless migration.

Fixes #59